### PR TITLE
Cast INTERVAL to float during scale_and_type()

### DIFF
--- a/collectd_cdn/fastly.py
+++ b/collectd_cdn/fastly.py
@@ -124,10 +124,10 @@ class CdnFastly(object):
             val = float(val)
         elif key.endswith('_size') or key == 'bandwidth':
             vtype = 'bytes'
-            val = val / INTERVAL
+            val = val / float(INTERVAL)
         else:
             vtype = 'requests'
-            val = val / INTERVAL
+            val = val / float(INTERVAL)
 
         return val, vtype
 

--- a/test/unit/test_fastly.py
+++ b/test/unit/test_fastly.py
@@ -183,14 +183,12 @@ class TestScaleAndType(TestFastly):
 
     def test_size(self):
         v, t = self.fastly.scale_and_type('body_size', 219004331934)
-        # FIXME: Should be float 3650072198.9 ?
-        assert_equal(v, 3650072198)
+        assert_equal(v, 3650072198.9)
         assert_equal(t, 'bytes')
 
     def test_other(self):
         v, t = self.fastly.scale_and_type('status_2xx', 11152796)
-        # FIXME: Should be float 185879.93333333332 ?
-        assert_equal(v, 185879)
+        assert_equal(v, 185879.93333333332)
         assert_equal(t, 'requests')
 
 
@@ -387,9 +385,9 @@ class TestRead(TestFastly):
             call('333', *range_mock),
         ]
         submit_calls = [
-            call('three', 'hits', 'requests', 777, 1390320360),
+            call('three', 'hits', 'requests', 777.6166666666667, 1390320360),
             call('three', 'hits_time', 'response_time', 3.5722524239999993, 1390320360),
-            call('one', 'hits', 'requests', 777, 1390320360),
+            call('one', 'hits', 'requests', 777.6166666666667, 1390320360),
             call('one', 'hits_time', 'response_time', 3.5722524239999993, 1390320360),
         ]
 


### PR DESCRIPTION
Casting INTERVAL to a float ensures that the divison returns a float rather than an integer. In Python 3 division will operate like this automatically, but for now we can force the desired behaviour.

This improves the accuracy of the data returned to collectd as noted in cf50005f3bf67e1c9c60c8ad49e69dfdc198deb3.
